### PR TITLE
Replace old gitlab url in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "git@gitlab.com:dx-solutions/dx/internal/coding-standard.git"
+            "url": "git@github.com:DX-Solutions/coding-standards.git"
         }
     ],
 ```


### PR DESCRIPTION
Replace the old gitlab url with the new github url in the README instructions